### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/test_auth.py
+++ b/test_auth.py
@@ -51,6 +51,15 @@ def test_authentication():
 
     return True
 
+def mask_secret(secret):
+    """Mask a secret for logging (show only first 2 and last 2 characters, if length > 6)."""
+    if not secret:
+        return "<not set>"
+    secret_str = str(secret)
+    if len(secret_str) <= 6:
+        return "*" * len(secret_str)
+    return f"{secret_str[:2]}{'*' * (len(secret_str)-4)}{secret_str[-2:]}"
+
 if __name__ == "__main__":
     # Check if environment variables are set to non-placeholder values
     client_id = os.environ.get('REDDIT_CLIENT_ID')
@@ -61,7 +70,7 @@ if __name__ == "__main__":
         print("   Get credentials from: https://www.reddit.com/prefs/apps")
         print("   Current values:")
         print(f"   REDDIT_CLIENT_ID: {client_id}")
-        print(f"   REDDIT_SECRET: {client_secret}")
+        print(f"   REDDIT_SECRET: {mask_secret(client_secret)}")
         exit(1)
 
     print("[OK] Environment variables loaded successfully")


### PR DESCRIPTION
Potential fix for [https://github.com/shoaib-fixes/sherlock/security/code-scanning/1](https://github.com/shoaib-fixes/sherlock/security/code-scanning/1)

The ideal fix is to avoid printing the full secret in cleartext. In the error case, it’s helpful to inform the user of whether the secret is set and possibly which value is present—but not the actual secret value. Instead, we can mask the secret before printing, e.g., by only displaying its length, an asterisked version, or the first/last few characters.  
Specifically, in `test_auth.py`, replace line 64 so it prints a masked representation of `client_secret`. A helper function `mask_secret(secret)` can be added in this file to mask the secret (e.g., show only the first 2 and last 2 characters, with asterisks in between), and use it in the print statement, like:  
`print(f"   REDDIT_SECRET: {mask_secret(client_secret)}")`  
No additional dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security by masking sensitive credentials in logs to prevent accidental exposure in debug output.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->